### PR TITLE
Add snoop utility

### DIFF
--- a/utils/snoop.config.json
+++ b/utils/snoop.config.json
@@ -1,0 +1,4 @@
+{
+  "aelmekeev": "https://year-on-facade.uk/",
+  "oobrien": "https://misc.oomap.co.uk/year-on-facade/"
+}

--- a/utils/snoop.sh
+++ b/utils/snoop.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 if [ "$#" -lt 2 ]; then
   echo "Usage: ./snoop.sh <author github id> <city name> <optional, alias for the city in author's repository>"
+  echo "Example: ./snoop.sh oobrien UK/London Middlesex"
   exit 1
 fi
 

--- a/utils/snoop.sh
+++ b/utils/snoop.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "Usage: ./snoop.sh <author github id> <city name> <optional, alias for the city in author's repository>"
+  exit 1
+fi
+
+author=$1
+city=$2
+city_remote="${3:-$city}"
+
+curl -sf https://raw.githubusercontent.com/$author/year-on-facade/main/csv/$city_remote.csv > remote.csv.tmp || (echo "Failed to get $city_remote from the $author repository" && exit 1)
+
+get_years="split(\"\\n\") | .[1:] | map(split(\",\")) | map(.[0]) | map(.[0:4]) | unique"
+
+cat "../csv/$city.csv" | jq -sRre "$get_years" > "local.json.tmp"
+cat remote.csv.tmp | jq -sRre "$get_years" > "remote.remote.json.tmp"
+
+echo "You probably can borrow below from https://github.com/$author/year-on-facade/blob/main/csv/$city_remote.csv"
+jq -sr ".[0] as \$config | .[2] - .[1] | map(\"- \" + \$config[\"$author\"] + \"item/?city="${city_remote##*/}"&year=\" + .) | .[]" snoop.config.json "local.json.tmp" "remote.remote.json.tmp"
+
+rm *.tmp


### PR DESCRIPTION
Usage example:

```bash
…/year-on-facade  snoop [$!] at 21:58:56 ✖ 127 ❯ cd utils 
…/year-on-facade/utils  snoop [$!] at 21:59:03 ❯ ./snoop.sh oobrien UK/London Middlesex
You probably can borrow below from https://github.com/oobrien/year-on-facade/blob/main/csv/Middlesex.csv
- https://misc.oomap.co.uk/year-on-facade/item/?city=Middlesex&year=1730
- https://misc.oomap.co.uk/year-on-facade/item/?city=Middlesex&year=1971
- https://misc.oomap.co.uk/year-on-facade/item/?city=Middlesex&year=2010
- https://misc.oomap.co.uk/year-on-facade/item/?city=Middlesex&year=2014
- https://misc.oomap.co.uk/year-on-facade/item/?city=Middlesex&year=2018
- https://misc.oomap.co.uk/year-on-facade/item/?city=Middlesex&year=2020
…/year-on-facade/utils  snoop [$!] at 21:59:06 ❯
```