### PR TITLE
Add photos-upload command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,6 @@ photos:
 
 photos-update:
 	./photos/optimise.sh update
+
+photos-upload:
+	aws-vault exec year-on-facade -- aws s3 sync ./photos/upload s3://year-on-facade


### PR DESCRIPTION
Simplifying new photos upload to s3 bucket.

TIL

For some reason S3 bucket needs the following bucket permission to be able to use s3 sync:

```json
{
            "Sid": "Upload",
            "Effect": "Allow",
            "Principal": {
                "AWS": "arn:aws:iam::914826113296:user/year-on-facade"
            },
            "Action": "s3:ListBucket",
            "Resource": "arn:aws:s3:::year-on-facade"
        }
```

Apparently [internet is full of lies](https://stackoverflow.com/questions/48894886/aws-permissions-required-for-sync) and all is needed in IAM policy is 

```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "Upload",
            "Effect": "Allow",
            "Action": [
                "s3:PutObject",
                "s3:ListBucket"
            ],
            "Resource": "arn:aws:s3:::year-on-facade/*"
        }
    ]
}
```

I doubt that it's because I do not use `--delete`